### PR TITLE
Load express middleware and routes only if dirs exist

### DIFF
--- a/components/express_webserver.js
+++ b/components/express_webserver.js
@@ -3,6 +3,7 @@ var bodyParser = require('body-parser');
 var querystring = require('querystring');
 var debug = require('debug')('botkit:webserver');
 var http = require('http');
+var fs = require('fs');
 
 module.exports = function(controller) {
 
@@ -12,10 +13,12 @@ module.exports = function(controller) {
     webserver.use(bodyParser.urlencoded({ extended: true }));
 
     // import express middlewares that are present in /components/express_middleware
-    var normalizedPath = require("path").join(__dirname, "express_middleware");
-    require("fs").readdirSync(normalizedPath).forEach(function(file) {
-        require("./express_middleware/" + file)(webserver, controller);
-    });
+    var normalizedPathToMiddleware = require('path').join(__dirname, 'express_middleware');
+    if (fs.existsSync(normalizedPathToMiddleware)) {
+        fs.readdirSync(normalizedPathToMiddleware).forEach(function(file) {
+            require('./express_middleware/' + file)(webserver, controller);
+        });
+    }
 
     webserver.use(express.static('public'));
 
@@ -28,14 +31,16 @@ module.exports = function(controller) {
     });
 
     // import all the pre-defined routes that are present in /components/routes
-    var normalizedPath = require("path").join(__dirname, "routes");
-    require("fs").readdirSync(normalizedPath).forEach(function(file) {
-      require("./routes/" + file)(webserver, controller);
-    });
+    var normalizedPathToRoutes = require('path').join(__dirname, 'routes');
+    if (fs.existsSync(normalizedPathToRoutes)) {
+        fs.readdirSync(normalizedPathToRoutes).forEach(function (file) {
+            require('./routes/' + file)(webserver, controller);
+        });
+    }
 
     controller.webserver = webserver;
     controller.httpserver = server;
 
     return webserver;
 
-}
+};


### PR DESCRIPTION
I deleted register_with_studio.js because I am not going to use botkit studio.
The routes directory was actually missing when I checked out this project, but I have no need for any routes yet.
Because of that both directories are empty and can't be committed to git.
Adding .gitkeep or .gitignore makes bot.js fail, because this code loads them as js files.

So it is the best to check if directories exists before reading them.
