### PR TITLE
Use websockets by default

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -4,13 +4,12 @@
     var messenger = {
       config: {
         ws_url: (location.protocol === 'https:' ? 'wss' : 'ws') + '://' + location.host,
-        http_url: (location.protocol === 'https:' ? 'wss' : 'ws') + '://' + location.host + '/botkit/receive',
         reconnect_timeout: 3000,
-        max_reconnect: 5,
+        max_reconnect: 5
       },
       options: {
         sound: false,
-        use_sockets: false,
+        use_sockets: true
       },
       reconnect_count: 0,
       guid: null,


### PR DESCRIPTION
Because websockets are better than webhooks.

Also I removed http_url field because it wasn't used anywhere.